### PR TITLE
Add 2 options on config text input component

### DIFF
--- a/nodes/ui_text_input.html
+++ b/nodes/ui_text_input.html
@@ -19,6 +19,8 @@
             },
             height: {value: 0},
             passthru: {value: true},
+            emitOnlyNewValues: {value: true},
+            storeFrontEndInputAsState: {value: true},
             mode: {value: 'text', required: true},
             delay: {value: 300, validate: RED.validators.number()},
             topic: {value: ''}
@@ -78,6 +80,14 @@
     <div class="form-row">
         <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-emitOnlyNewValues"><i class="fa fa-arrow-right"></i> Emit only new values: </label>
+        <input type="checkbox" checked id="node-input-emitOnlyNewValues" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-storeFrontEndInputAsState"><i class="fa fa-arrow-right"></i> Store front end input as state: </label>
+        <input type="checkbox" checked id="node-input-storeFrontEndInputAsState" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
     <div class="form-row">
         <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> When changed, send:</label>

--- a/nodes/ui_text_input.js
+++ b/nodes/ui_text_input.js
@@ -1,44 +1,53 @@
-module.exports = function(RED) {
-    var ui = require('../ui')(RED);
+module.exports = function (RED) {
+  var ui = require("../ui")(RED);
 
-    function TextInputNode(config) {
-        RED.nodes.createNode(this, config);
-        var node = this;
+  function TextInputNode(config) {
+    RED.nodes.createNode(this, config);
+    var node = this;
 
-        var group = RED.nodes.getNode(config.group);
-        if (!group) { return; }
-        var tab = RED.nodes.getNode(group.config.tab);
-        if (!tab) { return; }
-
-        var done = ui.add({
-            node: node,
-            tab: tab,
-            group: group,
-            forwardInputMessages: config.passthru,
-            storeFrontEndInputAsState: false,
-            control: {
-                type: (config.delay <= 0 ? 'text-input-CR' : 'text-input'),
-                label: config.label,
-                tooltip: config.tooltip,
-                mode: config.mode,
-                delay: config.delay,
-                order: config.order,
-                value: '',
-                width: config.width || group.config.width || 6,
-                height: config.height || 1
-            },
-            beforeSend: function (msg) {
-                if (config.mode === "time") {
-                    if (typeof msg.payload === "string") {
-                        msg.payload = Date.parse(msg.payload);
-                    }
-                }
-                // if (config.mode === "week") { msg.payload = Date.parse(msg.payload); }
-                // if (config.mode === "month") { msg.payload = Date.parse(msg.payload); }
-                msg.topic = config.topic || msg.topic;
-            }
-        });
-        node.on("close", done);
+    var group = RED.nodes.getNode(config.group);
+    if (!group) {
+      return;
     }
-    RED.nodes.registerType("mui_text_input", TextInputNode);
+    var tab = RED.nodes.getNode(group.config.tab);
+    if (!tab) {
+      return;
+    }
+
+    var done = ui.add({
+      node: node,
+      tab: tab,
+      group: group,
+      // Teste Concert
+      emitOnlyNewValues: config.emitOnlyNewValues, //false,
+      // *****
+      forwardInputMessages: config.passthru,
+      // Teste Concert
+      storeFrontEndInputAsState: config.storeFrontEndInputAsState, //true,
+      // *****
+      control: {
+        type: config.delay <= 0 ? "text-input-CR" : "text-input",
+        label: config.label,
+        tooltip: config.tooltip,
+        mode: config.mode,
+        delay: config.delay,
+        order: config.order,
+        value: "",
+        width: config.width || group.config.width || 6,
+        height: config.height || 1,
+      },
+      beforeSend: function (msg) {
+        if (config.mode === "time") {
+          if (typeof msg.payload === "string") {
+            msg.payload = Date.parse(msg.payload);
+          }
+        }
+        // if (config.mode === "week") { msg.payload = Date.parse(msg.payload); }
+        // if (config.mode === "month") { msg.payload = Date.parse(msg.payload); }
+        msg.topic = config.topic || msg.topic;
+      },
+    });
+    node.on("close", done);
+  }
+  RED.nodes.registerType("mui_text_input", TextInputNode);
 };


### PR DESCRIPTION
Hi!

I'm Alexandre and in my node-red flow, it's necessary to update and store values on the text-input component.

By default, this component update if a new value is received and it's necessary to update all the time, and the actual value doesn't store on the component and doesn't pass through this value.

So, I put two config values on for modification of this component when necessary:

- Emit only new values: if true, update a stored value when this value is new, otherwise update all the time;
- Store front end input as the state: if true, the actual value is stored on component, otherwise don't.

![image](https://user-images.githubusercontent.com/3682611/99992736-81715f80-2d95-11eb-8b28-b4b64e90e93f.png)

![image](https://user-images.githubusercontent.com/3682611/99992855-a796ff80-2d95-11eb-8d8c-4d9faa918a42.png)
